### PR TITLE
[#26] Report shellcheck as *error* instead of warnings in the log

### DIFF
--- a/ci/build.sh
+++ b/ci/build.sh
@@ -39,7 +39,7 @@ while read -r folder; do
 	cd "${folder}"
 	echo "Checking and building ${folder} ..."
 	docker run --rm -i hadolint/hadolint < Dockerfile
-	find . -name '*.sh' -exec shellcheck {} \;
+	find . -name '*.sh' -type f -print0 | xargs -0 -r -n1 shellcheck
 	image_name="akvo/akvo-${folder}"
 	docker build -t "${image_name}:${tag}" .
 

--- a/devops/Dockerfile
+++ b/devops/Dockerfile
@@ -5,7 +5,7 @@ USER root
 
 RUN set -x \
     && apk add -u --no-cache curl~=7 jq~=1 bash~=4 shadow~=4.5 runit~=2.1 \
-    && curl -o /usr/bin/slack-cli https://raw.githubusercontent.com/rockymadden/slack-cli/master/src/slack \
+    && curl -o /usr/bin/slack-cli https://github.com/rockymadden/slack-cli/blob/v0.18.0/src/slack \
     && chmod +x /usr/bin/slack-cli \
     && slack-cli -v
 

--- a/devops/helpers/generate-zulip-notification.sh
+++ b/devops/helpers/generate-zulip-notification.sh
@@ -1,10 +1,8 @@
-
+#!/usr/bin/env bash
 
 OLDER_GIT_VERSION=$1
 NEWEST_GIT_VERSION=$2
 MSG=$3
-COLOR=$4
-WRAP_SLACK=$5
 GITHUB_PROJECT=$6
 
 cat << EOF > notify.team.sh
@@ -25,7 +23,7 @@ curl -X POST https://akvo.zulipchat.com/api/v1/messages \
     -d "type=stream" \
     -d "to=rsr" \
     -d "topic=Releases" \
-    -d $"content=$MSG. [Full diff](https://github.com/akvo/${GITHUB_PROJECT}/compare/$OLDER_GIT_VERSION..$NEWEST_GIT_VERSION).
+    -d "content=$MSG. [Full diff](https://github.com/akvo/${GITHUB_PROJECT}/compare/$OLDER_GIT_VERSION..$NEWEST_GIT_VERSION).
 
 \$slack_txt"
 

--- a/devops/promote-test-to-prod.sh
+++ b/devops/promote-test-to-prod.sh
@@ -41,7 +41,7 @@ log "See https://github.com/akvo/${GITHUB_PROJECT}/compare/$PROD_VERSION..$TEST_
 
 log "Commits to be deployed:"
 echo ""
-git log --oneline $PROD_VERSION..$TEST_VERSION | grep -v "Merge pull request" | grep -v "Merge branch"
+git log --oneline "${PROD_VERSION}..${TEST_VERSION}" | grep -v "Merge pull request" | grep -v "Merge branch"
 
 "generate-${NOTIFICATION}-notification.sh" "${PROD_VERSION}" "${TEST_VERSION}" "I am thinking about deploying ${GITHUB_PROJECT} to production. Should I?" "warning" "dont_wrap" "$GITHUB_PROJECT"
 ./notify.team.sh


### PR DESCRIPTION
The shellcheck problems were reported but not considered errors. If we
need to maintain those scripts we should have them as tidy as
possible.

Checking and building devops ...

===

In ./promote-test-to-prod.sh line 44:
git log --oneline $PROD_VERSION..$TEST_VERSION | grep -v "Merge pull request" | grep -v "Merge branch"
                  ^-----------^ SC2086: Double quote to prevent globbing and word splitting.
		                                   ^-----------^ SC2086: Double quote to prevent globbing and word splitting.

For more information:
  https://www.shellcheck.net/wiki/SC2086 -- Double quote to prevent globbing ...

In ./helpers/generate-zulip-notification.sh line 1:

^-- SC2148: Tips depend on target shell and yours is unknown. Add a shebang.

In ./helpers/generate-zulip-notification.sh line 6:
COLOR=$4
^---^ SC2034: COLOR appears unused. Verify use (or export if used externally).

===

Full log: https://storage.cloud.google.com/akvo-public/travis-build-log-690870380.txt