### PR TITLE
[#26] Use --no-merges instead of `grep -v`

### DIFF
--- a/devops/flow/flip-production-traffic.sh
+++ b/devops/flow/flip-production-traffic.sh
@@ -44,7 +44,7 @@ fi
 
 log "Changes to be deployed: https://github.com/akvo/${GITHUB_PROJECT}/compare/$PROD_LIVE_VERSION..$NEW_LIVE_VERSION"
 log "Commits to be deployed:"
-git log --oneline --no-merges "$PROD_LIVE_VERSION".."$NEW_LIVE_VERSION"
+git --no-pager log --oneline --no-merges "$PROD_LIVE_VERSION".."$NEW_LIVE_VERSION"
 
 generate-slack-notification.sh "${PROD_LIVE_VERSION}" "${NEW_LIVE_VERSION}" "I am thinking about flipping **FLOW prod** to make this changes live. Should I?" "warning"
 ./notify.team.sh

--- a/devops/flow/flip-production-traffic.sh
+++ b/devops/flow/flip-production-traffic.sh
@@ -44,7 +44,7 @@ fi
 
 log "Changes to be deployed: https://github.com/akvo/${GITHUB_PROJECT}/compare/$PROD_LIVE_VERSION..$NEW_LIVE_VERSION"
 log "Commits to be deployed:"
-git log --oneline "$PROD_LIVE_VERSION".."$NEW_LIVE_VERSION" | grep -v "Merge pull request" | grep -v "Merge branch"
+git log --oneline --no-merges "$PROD_LIVE_VERSION".."$NEW_LIVE_VERSION"
 
 generate-slack-notification.sh "${PROD_LIVE_VERSION}" "${NEW_LIVE_VERSION}" "I am thinking about flipping **FLOW prod** to make this changes live. Should I?" "warning"
 ./notify.team.sh

--- a/devops/flow/promote-test-to-prod.sh
+++ b/devops/flow/promote-test-to-prod.sh
@@ -62,7 +62,7 @@ fi
 log "Commits to be deployed:"
 echo ""
 
-git log --oneline "$NEWEST_VERSION_IN_PROD".."$TEST_LIVE_VERSION" | grep -v "Merge pull request" | grep -v "Merge branch"
+git log --oneline --no-merges "$NEWEST_VERSION_IN_PROD".."$TEST_LIVE_VERSION"
 
 TAG_NAME="promote-$(TZ=UTC date +"%Y%m%d-%H%M%S")"
 

--- a/devops/flow/promote-test-to-prod.sh
+++ b/devops/flow/promote-test-to-prod.sh
@@ -62,7 +62,7 @@ fi
 log "Commits to be deployed:"
 echo ""
 
-git log --oneline --no-merges "$NEWEST_VERSION_IN_PROD".."$TEST_LIVE_VERSION"
+git --no-pager log --oneline --no-merges "$NEWEST_VERSION_IN_PROD".."$TEST_LIVE_VERSION"
 
 TAG_NAME="promote-$(TZ=UTC date +"%Y%m%d-%H%M%S")"
 

--- a/devops/helpers/generate-slack-notification.sh
+++ b/devops/helpers/generate-slack-notification.sh
@@ -17,7 +17,7 @@ if [ -z "\${SLACK_CLI_TOKEN}" ]; then
   exit 1
 fi
 
-slack_txt=\$(git log --oneline $OLDER_GIT_VERSION..$NEWEST_GIT_VERSION | grep -v "Merge pull request" | grep -v "Merge branch" | cut -f 2- -d\  | sed 's/\[#\([0-9]*\)\]/<https:\/\/github.com\/akvo\/${GITHUB_PROJECT}\/issues\/\1|[#\1]>/' | tr \" \')
+slack_txt=\$(git log --oneline --no-merges $OLDER_GIT_VERSION..$NEWEST_GIT_VERSION | cut -f 2- -d\  | sed 's/\[#\([0-9]*\)\]/<https:\/\/github.com\/akvo\/${GITHUB_PROJECT}\/issues\/\1|[#\1]>/' | tr \" \')
 
 if [ $WRAP_SLACK == "wrap_slack" ]; then
   CMD="docker run --rm -e SLACK_CLI_TOKEN 512k/slack-cli"

--- a/devops/helpers/generate-slack-notification.sh
+++ b/devops/helpers/generate-slack-notification.sh
@@ -17,7 +17,7 @@ if [ -z "\${SLACK_CLI_TOKEN}" ]; then
   exit 1
 fi
 
-slack_txt=\$(git log --oneline --no-merges $OLDER_GIT_VERSION..$NEWEST_GIT_VERSION | cut -f 2- -d\  | sed 's/\[#\([0-9]*\)\]/<https:\/\/github.com\/akvo\/${GITHUB_PROJECT}\/issues\/\1|[#\1]>/' | tr \" \')
+slack_txt=\$(git --no-pager log --oneline --no-merges $OLDER_GIT_VERSION..$NEWEST_GIT_VERSION | cut -f 2- -d\  | sed 's/\[#\([0-9]*\)\]/<https:\/\/github.com\/akvo\/${GITHUB_PROJECT}\/issues\/\1|[#\1]>/' | tr \" \')
 
 if [ $WRAP_SLACK == "wrap_slack" ]; then
   CMD="docker run --rm -e SLACK_CLI_TOKEN 512k/slack-cli"

--- a/devops/helpers/generate-zulip-notification.sh
+++ b/devops/helpers/generate-zulip-notification.sh
@@ -16,7 +16,7 @@ if [ -z "\${ZULIP_CLI_TOKEN}" ]; then
   exit 1
 fi
 
-slack_txt=\$(git log --oneline $OLDER_GIT_VERSION..$NEWEST_GIT_VERSION | grep -v "Merge pull request" | grep -v "Merge branch" | cut -f 2- -d\  | sed 's/\[#\([0-9]*\)\]/#\1/' | tr \" \' | tr \& \ )
+slack_txt=\$(git log --oneline --no-merges $OLDER_GIT_VERSION..$NEWEST_GIT_VERSION | cut -f 2- -d\  | sed 's/\[#\([0-9]*\)\]/#\1/' | tr \" \' | tr \& \ )
 
 curl -X POST https://akvo.zulipchat.com/api/v1/messages \
     -u "\${ZULIP_CLI_TOKEN}" \

--- a/devops/helpers/generate-zulip-notification.sh
+++ b/devops/helpers/generate-zulip-notification.sh
@@ -16,7 +16,7 @@ if [ -z "\${ZULIP_CLI_TOKEN}" ]; then
   exit 1
 fi
 
-slack_txt=\$(git log --oneline --no-merges $OLDER_GIT_VERSION..$NEWEST_GIT_VERSION | cut -f 2- -d\  | sed 's/\[#\([0-9]*\)\]/#\1/' | tr \" \' | tr \& \ )
+slack_txt=\$(git --no-pager log --oneline --no-merges $OLDER_GIT_VERSION..$NEWEST_GIT_VERSION | cut -f 2- -d\  | sed 's/\[#\([0-9]*\)\]/#\1/' | tr \" \' | tr \& \ )
 
 curl -X POST https://akvo.zulipchat.com/api/v1/messages \
     -u "\${ZULIP_CLI_TOKEN}" \

--- a/devops/promote-test-to-prod.sh
+++ b/devops/promote-test-to-prod.sh
@@ -44,7 +44,7 @@ git fetch
 
 log "Commits to be deployed:"
 echo ""
-git log --oneline --no-merges "${PROD_VERSION}..${TEST_VERSION}"
+git --no-pager log --oneline --no-merges "${PROD_VERSION}..${TEST_VERSION}"
 
 "generate-${NOTIFICATION}-notification.sh" "${PROD_VERSION}" "${TEST_VERSION}" "I am thinking about deploying ${GITHUB_PROJECT} to production. Should I?" "warning" "dont_wrap" "$GITHUB_PROJECT"
 ./notify.team.sh

--- a/devops/promote-test-to-prod.sh
+++ b/devops/promote-test-to-prod.sh
@@ -44,7 +44,7 @@ git fetch
 
 log "Commits to be deployed:"
 echo ""
-git log --oneline "${PROD_VERSION}..${TEST_VERSION}" | grep -v "Merge pull request" | grep -v "Merge branch"
+git log --oneline --no-merges "${PROD_VERSION}..${TEST_VERSION}"
 
 "generate-${NOTIFICATION}-notification.sh" "${PROD_VERSION}" "${TEST_VERSION}" "I am thinking about deploying ${GITHUB_PROJECT} to production. Should I?" "warning" "dont_wrap" "$GITHUB_PROJECT"
 ./notify.team.sh


### PR DESCRIPTION
By using `git log --online | grep -v "Merge pull request" | grep -v "Merge branch"`
we're filtering out all merge commits.

> --no-merges
>    Do not print commits with more than one parent.
>    This is exactly the same as --max-parents=1.

https://www.git-scm.com/docs/git-log