### PR TITLE
Revert "Fetch latest changes from remote before generating diff"

### DIFF
--- a/devops/promote-test-to-prod.sh
+++ b/devops/promote-test-to-prod.sh
@@ -39,9 +39,6 @@ log "Deployed test version is $TEST_VERSION"
 log "Deployed prod version is $PROD_VERSION"
 log "See https://github.com/akvo/${GITHUB_PROJECT}/compare/$PROD_VERSION..$TEST_VERSION"
 
-log "Fetching latest code from remote"
-git fetch
-
 log "Commits to be deployed:"
 echo ""
 git --no-pager log --oneline --no-merges "${PROD_VERSION}..${TEST_VERSION}"


### PR DESCRIPTION
This reverts commit 9b78697f5be3a3afb85de146b5ec6d296e989b3b. Fetching
the content inside the docker container doesn't work because of using
the `git` URLs. We should instead move this fetch to the promote scripts
wherever this script is being called from.