### PR TITLE
[#40] Show commits "chronologically" in Zulip messages

### DIFF
--- a/devops/promote-test-to-prod.sh
+++ b/devops/promote-test-to-prod.sh
@@ -42,7 +42,7 @@ log "See https://github.com/akvo/${GITHUB_PROJECT}/compare/$PROD_VERSION..$TEST_
 
 log "Commits to be deployed:"
 echo ""
-git --no-pager log --oneline --no-merges "${PROD_VERSION}..${TEST_VERSION}"
+git --no-pager log --reverse --oneline --no-merges "${PROD_VERSION}..${TEST_VERSION}"
 
 "generate-${NOTIFICATION}-notification.sh" "${PROD_VERSION}" "${TEST_VERSION}" "I am thinking about deploying **${GITHUB_PROJECT}** to production. Should I?" "warning" "dont_wrap" "$GITHUB_PROJECT" "$ZULIP_STREAM"
 ./notify.team.sh


### PR DESCRIPTION
git log shows the "newest" commit at the top, and this is fine for a
familiar UI (with a pager), where the number of commits can be a lot.
When printing the commit messages in a chat message, it is easier to
understand the change with the commit messages ordered
"chronologically", rather than reverse "chronologically".

"newest" and "chronologically" are used loosely here -- they mean the
order in which they appear in the git branching tree, and don't really
have anything to do with the time when they were committed, etc.