### PR TITLE
[#43] Improve Keycloak container startup time

### DIFF
--- a/keycloak-dev/Dockerfile
+++ b/keycloak-dev/Dockerfile
@@ -41,8 +41,6 @@ ENV KEYCLOAK_VERSION 3.4.3.Final
 
 EXPOSE 8080
 
-
-
 WORKDIR /opt/jboss/keycloak
 
 ENTRYPOINT ["/opt/jboss/keycloak/bin/standalone.sh"]

--- a/keycloak-dev/Dockerfile
+++ b/keycloak-dev/Dockerfile
@@ -21,6 +21,4 @@ COPY --from=build /opt/jboss/keycloak/standalone/data/keycloak.mv.db \
 COPY --from=build /opt/jboss/keycloak/standalone/configuration/standalone.xml \
 	/opt/jboss/keycloak/standalone/configuration/standalone.xml
 
-RUN set -ex; chown jboss:jboss /opt/jboss/keycloak/standalone/ -R
-
 CMD ["-b", "0.0.0.0"]

--- a/keycloak-dev/Dockerfile
+++ b/keycloak-dev/Dockerfile
@@ -1,3 +1,6 @@
+# Original
+FROM jboss/keycloak:3.4.3.Final as base
+
 # Build
 FROM jboss/keycloak:3.4.3.Final as build
 
@@ -14,11 +17,34 @@ RUN set -ex; \
     bash ./bin/jboss-cli.sh --file=/tmp/manual-migration.cli
 
 # Runtime
-FROM jboss/keycloak:3.4.3.Final
+FROM adoptopenjdk/openjdk8:jre8u272-b10-alpine
+
+RUN set -ex; \
+    apk add --no-cache bash=~5 && \
+    addgroup -g 1000 jboss && \
+    adduser -h /opt/jboss -s /bin/bash -G jboss -u 1000 -D jboss && \
+    chown 755 /opt/jboss
+
+USER jboss
+
+COPY --from=base /opt/jboss/keycloak/ /opt/jboss/keycloak/
 
 COPY --from=build /opt/jboss/keycloak/standalone/data/keycloak.mv.db \
 	/opt/jboss/keycloak/standalone/data/keycloak.mv.db
+
 COPY --from=build /opt/jboss/keycloak/standalone/configuration/standalone.xml \
 	/opt/jboss/keycloak/standalone/configuration/standalone.xml
+
+ENV LAUNCH_JBOSS_IN_BACKGROUND 1
+ENV PROXY_ADDRESS_FORWARDING false
+ENV KEYCLOAK_VERSION 3.4.3.Final
+
+EXPOSE 8080
+
+
+
+WORKDIR /opt/jboss/keycloak
+
+ENTRYPOINT ["/opt/jboss/keycloak/bin/standalone.sh"]
 
 CMD ["-b", "0.0.0.0"]

--- a/keycloak-dev/Dockerfile
+++ b/keycloak-dev/Dockerfile
@@ -1,11 +1,26 @@
-FROM jboss/keycloak:3.4.3.Final
+# Build
+FROM jboss/keycloak:3.4.3.Final as build
 
 COPY akvo.json /tmp/akvo.json
+COPY manual-migration.cli /tmp/manual-migration.cli
 
-ENV KEYCLOAK_USER=admin
-ENV KEYCLOAK_PASSWORD=admin
+USER jboss
 
-CMD ["-b", "0.0.0.0", "-Dkeycloak.migration.action=import", \
-     "-Dkeycloak.migration.provider=singleFile", \
-     "-Dkeycloak.migration.file=/tmp/akvo.json", \
-     "-Dkeycloak.migration.strategy=IGNORE_EXISTING"]
+WORKDIR /opt/jboss/keycloak
+
+ENV JAVA_OPTS="-server -Xms64m -Xmx512m"
+
+RUN set -ex; \
+    bash ./bin/jboss-cli.sh --file=/tmp/manual-migration.cli
+
+# Runtime
+FROM jboss/keycloak:3.4.3.Final
+
+COPY --from=build /opt/jboss/keycloak/standalone/data/keycloak.mv.db \
+	/opt/jboss/keycloak/standalone/data/keycloak.mv.db
+COPY --from=build /opt/jboss/keycloak/standalone/configuration/standalone.xml \
+	/opt/jboss/keycloak/standalone/configuration/standalone.xml
+
+RUN set -ex; chown jboss:jboss /opt/jboss/keycloak/standalone/ -R
+
+CMD ["-b", "0.0.0.0"]

--- a/keycloak-dev/manual-migration.cli
+++ b/keycloak-dev/manual-migration.cli
@@ -1,0 +1,17 @@
+embed-server --std-out=echo
+
+/system-property=keycloak.migration.action:add(value=import)
+/system-property=keycloak.migration.provider:add(value=singleFile)
+/system-property=keycloak.migration.file:add(value=/tmp/akvo.json)
+/system-property=keycloak.migration.strategy:add(value=IGNORE_EXISTING)
+
+reload --admin-only=false
+
+/system-property=keycloak.migration.action:remove
+/system-property=keycloak.migration.provider:remove
+/system-property=keycloak.migration.file:remove
+/system-property=keycloak.migration.strategy:remove
+
+/subsystem=keycloak-server/spi=connectionsJpa/provider=default/:map-put(name=properties,key=migrationStrategy,value=manual)
+
+quit


### PR DESCRIPTION
* We're now using a multi-stage build. First we prepare the H2
embedded database with the migration and the `akvo` realm imported.
We also modify the server configuration to have a "manual" migration
for database.

* We prepare 2 files `keycloak.mv.db` and `standalone.xml` in the
build step.

* We copy those files to the resulting Keycloak image in the proper
place and remove the instructions to import realm when starting the
server.

* We're using an Alpine linux base image to reduce the size of the container in ~50%

Closes #43 